### PR TITLE
added test for global ip in return statement of pickInterface

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ function pickInterface (interfaces, family) {
   for (var i in interfaces) {
     for (var j = interfaces[i].length - 1; j >= 0; j--) {
       var face = interfaces[i][j]
-      if (!face.internal && face.family === family) return face.address
+      if (!face.internal && face.family === family && face.scopeid === 0) return face.address
     }
   }
   return family === 'IPv4' ? '127.0.0.1' : '::1'


### PR DESCRIPTION
 There is a bug in pickInterface where ipv6() would return link local addresses because it didn't check the scopeid of the address. (scopid 0 is a global address).

Added a test to the return statement in the simplest way possible to make sure only a global address is returned.