### PR TITLE
Fix scopeid check for IPv4 addresses

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,8 @@ function pickInterface (interfaces, family) {
   for (var i in interfaces) {
     for (var j = interfaces[i].length - 1; j >= 0; j--) {
       var face = interfaces[i][j]
-      if (!face.internal && face.family === family && face.scopeid === 0) return face.address
+      var reachable = family === 'IPv4' || face.scopeid === 0
+      if (!face.internal && face.family === family && reachable) return face.address
     }
   }
   return family === 'IPv4' ? '127.0.0.1' : '::1'


### PR DESCRIPTION
https://github.com/mafintosh/network-address/pull/3 broke IPv4 addresses, `scopeid` is only valid for IPv6.